### PR TITLE
SDK Parameter Modifications: rename userUrl, rename handleClose

### DIFF
--- a/Examples/column-swiftui-example/column-ios/ContentView.swift
+++ b/Examples/column-swiftui-example/column-ios/ContentView.swift
@@ -35,7 +35,7 @@ struct ContentView: View {
                         .border(Color(.white), width: 5)
                 }.sheet(isPresented: $activeWebView, content: {
                     // open the Column Tax SDK
-                    ColumnTaxView(
+                    ColumnTaxFile(
                         userUrl: URL(string: getUrlText())!,
                         isPresented: self.$activeWebView,
                         handleClose: self.handleClose

--- a/Examples/column-swiftui-example/column-ios/ContentView.swift
+++ b/Examples/column-swiftui-example/column-ios/ContentView.swift
@@ -34,7 +34,7 @@ struct ContentView: View {
                         .padding()
                         .border(Color(.white), width: 5)
                 }.sheet(isPresented: $activeWebView, content: {
-                    // open the Column Tax SDK
+                    // open the Column Tax SDK!
                     ColumnTaxFile(
                         userUrl: URL(string: getUrlText())!,
                         isPresented: self.$activeWebView,

--- a/Examples/column-swiftui-example/column-ios/ContentView.swift
+++ b/Examples/column-swiftui-example/column-ios/ContentView.swift
@@ -36,9 +36,9 @@ struct ContentView: View {
                 }.sheet(isPresented: $activeWebView, content: {
                     // open the Column Tax SDK
                     ColumnTaxView(
-                        userUrlRequest: URLRequest(url: URL(string: getUrlText())!),
+                        userUrl: URL(string: getUrlText())!,
                         isPresented: self.$activeWebView,
-                        onClose: self.handleClose
+                        handleClose: self.handleClose
                     ).edgesIgnoringSafeArea(.all)
                 })
             }

--- a/Sources/ColumnTaxFile/ColumnTaxFile.swift
+++ b/Sources/ColumnTaxFile/ColumnTaxFile.swift
@@ -71,7 +71,7 @@ class ScriptMessageHandler: NSObject, WKScriptMessageHandler {
     }
 }
 
-public struct ColumnTaxView: UIViewRepresentable {
+public struct ColumnTaxFile: UIViewRepresentable {
     let userUrl: URL
     @Binding var isPresented: Bool
     var handleClose: () -> Void // Closure to handle close event


### PR DESCRIPTION
A few modifications to the SDK shape:
- Rename `ColumnTaxView` to `ColumnTaxFile
- Change `userUrlRequest` to `userUrl`
- Rename `onClose` to `handleClose`